### PR TITLE
LightApp: Fix compilation without PV3DViewer

### DIFF
--- a/src/LightApp/LightApp_Application.cxx
+++ b/src/LightApp/LightApp_Application.cxx
@@ -2141,6 +2141,7 @@ SUIT_ViewManager* LightApp_Application::createViewManager( const QString& vmType
   if ( vmType == PV3DViewer_ViewModel::Type() )
 # endif
   {
+# ifndef DISABLE_SALOMEOBJECT
     viewMgr = new SPV3D_ViewManager( activeStudy(), desktop() );
     SPV3D_ViewModel* vm = dynamic_cast<SPV3D_ViewModel*>( viewMgr->getViewModel() );
     if ( vm )
@@ -2159,6 +2160,7 @@ SUIT_ViewManager* LightApp_Application::createViewManager( const QString& vmType
     }
 #endif
   }
+#endif
 
   if ( !viewMgr )
     return 0;


### PR DESCRIPTION
When compiling a minimal gui with -DSALOME_USE_PV3DVIEWER=OFF it errors with:
```
/home/devel/src/gui/src/LightApp/LightApp_Application.cxx: In member function ‘virtual SUIT_ViewManager* LightApp_Application::createViewManager(const QString&, bool)’:
/home/devel/src/gui/src/LightApp/LightApp_Application.cxx:2154:19: error: expected type-specifier before ‘PV3DViewer_ViewManager’
 2154 |     viewMgr = new PV3DViewer_ViewManager( activeStudy(), desktop() );
      |                   ^~~~~~~~~~~~~~~~~~~~~~
/home/devel/src/gui/src/LightApp/LightApp_Application.cxx:2155:5: error: ‘PV3DViewer_ViewModel’ was not declared in this scope; did you mean ‘PyViewer_Viewer’?
 2155 |     PV3DViewer_ViewModel* vm = dynamic_cast<PV3DViewer_ViewModel*>( viewMgr->getViewModel() );
      |     ^~~~~~~~~~~~~~~~~~~~
      |     PyViewer_Viewer
/home/devel/src/gui/src/LightApp/LightApp_Application.cxx:2155:27: error: ‘vm’ was not declared in this scope; did you mean ‘tm’?
 2155 |     PV3DViewer_ViewModel* vm = dynamic_cast<PV3DViewer_ViewModel*>( viewMgr->getViewModel() )
```
seems the second condition is just not guarded by DISABLE_SALOMEOBJECT
compilation goes through after this patch
cc @nitawa